### PR TITLE
img-boot: specify correct display path & brightness and update submodule.

### DIFF
--- a/rpm/droid-hal-kirin-img-boot.spec
+++ b/rpm/droid-hal-kirin-img-boot.spec
@@ -5,7 +5,7 @@
 %define root_part_label userdata
 %define factory_part_label system_b
 
-%define display_brightness_path /sys/class/leds/lcd-backlight/brightness
-%define display_brightness 16
+%define display_brightness_path /sys/class/backlight/panel0-backlight/brightness
+%define display_brightness 1024
 
 %include initrd/droid-hal-device-img-boot.inc

--- a/rpm/droid-hal-mermaid-img-boot.spec
+++ b/rpm/droid-hal-mermaid-img-boot.spec
@@ -5,7 +5,7 @@
 %define root_part_label userdata
 %define factory_part_label system_b
 
-%define display_brightness_path /sys/class/leds/lcd-backlight/brightness
-%define display_brightness 16
+%define display_brightness_path /sys/class/backlight/panel0-backlight/brightness
+%define display_brightness 1024
 
 %include initrd/droid-hal-device-img-boot.inc


### PR DESCRIPTION
[img-boot] specify correct display path & brightness and update submodule. JB#46664
The value is 1/4 of the maximum display brightness which is still nicely readable.