### PR TITLE
initrd: Update submodule

### DIFF
--- a/rpm/droid-hal-kirin-img-boot.spec
+++ b/rpm/droid-hal-kirin-img-boot.spec
@@ -10,7 +10,4 @@
 
 %define lvm_root_size 4000
 
-# mkbootimg needs python
-BuildRequires:  python
-
 %include initrd/droid-hal-device-img-boot.inc

--- a/rpm/droid-hal-mermaid-img-boot.spec
+++ b/rpm/droid-hal-mermaid-img-boot.spec
@@ -10,7 +10,4 @@
 
 %define lvm_root_size 4000
 
-# mkbootimg needs python
-BuildRequires:  python
-
 %include initrd/droid-hal-device-img-boot.inc


### PR DESCRIPTION
- [initrd] Add support for creating custom vendor_boot image
- [initrd] Only pull in droid-hal-tools in if needed, else use shared mkbootimg. JB#51936