### PR TITLE
[initrd] Fix boot mode detection. JB#63708

### DIFF
--- a/initrd-kirin/sbin/select-init-mode
+++ b/initrd-kirin/sbin/select-init-mode
@@ -1,6 +1,8 @@
 #!/bin/sh
-if grep -q "skip_initramfs" /proc/cmdline; then
-    echo "/normal-init"
-else
+if grep -q "warmboot=0x77665502" /proc/cmdline; then
     echo "/recovery-init"
+elif yamui-powerkey -p -k VOLUMEDOWN; then
+    echo "/recovery-init"
+else
+    echo "/normal-init"
 fi

--- a/rpm/droid-hal-kirin-img-boot.spec
+++ b/rpm/droid-hal-kirin-img-boot.spec
@@ -12,4 +12,7 @@
 
 %define initrd_combined 1
 
+# Extra key handling in yamui-powerkey
+BuildRequires: yamui >= 1.4.0
+
 %include initrd/droid-hal-device-img-boot.inc

--- a/rpm/droid-hal-mermaid-img-boot.spec
+++ b/rpm/droid-hal-mermaid-img-boot.spec
@@ -12,4 +12,7 @@
 
 %define initrd_combined 1
 
+# Extra key handling in yamui-powerkey
+BuildRequires: yamui >= 1.4.0
+
 %include initrd/droid-hal-device-img-boot.inc


### PR DESCRIPTION
The skip_initramfs cmdline parameter is not reliable, and does not handle warmboot, i.e. programmatic reboot to recovery.