### PR TITLE
initrd: Update submodule

### DIFF
--- a/rpm/droid-hal-kirin-img-boot.spec
+++ b/rpm/droid-hal-kirin-img-boot.spec
@@ -4,6 +4,7 @@
 
 %define root_part_label userdata
 %define factory_part_label system_b
+%define bcb_part_path /dev/mmcblk0p60
 
 %define display_brightness_path /sys/class/backlight/panel0-backlight/brightness
 %define display_brightness 1024

--- a/rpm/droid-hal-mermaid-img-boot.spec
+++ b/rpm/droid-hal-mermaid-img-boot.spec
@@ -4,6 +4,7 @@
 
 %define root_part_label userdata
 %define factory_part_label system_b
+%define bcb_part_path /dev/mmcblk0p60
 
 %define display_brightness_path /sys/class/backlight/panel0-backlight/brightness
 %define display_brightness 1024


### PR DESCRIPTION
[initrd] Add BCB clearing. JB#63708
[recovery] Start powerkey-handler earlier.
[mksfosinitrd] Do not add timestamp in gzipped rootfs. JB#60103